### PR TITLE
add basis for a data source to retrieve group role management policy id

### DIFF
--- a/docs/data-sources/group_role_management_policy.md
+++ b/docs/data-sources/group_role_management_policy.md
@@ -24,7 +24,7 @@ resource "azuread_group" "example" {
 
 data "azuread_group_role_management_policy" "owners_policy" {
   group_id = azuread_group.example.id
-  role_id = "owner"
+  role_id  = "owner"
 }
 ```
 

--- a/docs/data-sources/group_role_management_policy.md
+++ b/docs/data-sources/group_role_management_policy.md
@@ -1,0 +1,40 @@
+---
+subcategory: "Policies"
+---
+
+# Data Source: azuread_group_role_management_policy
+
+Use this data source to retrieve a role policy for an Azure AD group.
+
+## API Permissions
+
+The following API permissions are required in order to use this resource.
+
+When authenticated with a service principal, this resource requires the `RoleManagementPolicy.ReadWrite.AzureADGroup` Microsoft Graph API permissions.
+
+When authenticated with a user principal, this resource requires `Global Administrator` directory role, or the `Privileged Role Administrator` role in Identity Governance.
+
+## Example Usage
+
+```terraform
+resource "azuread_group" "example" {
+  display_name     = "group-name"
+  security_enabled = true
+}
+
+data "azuread_group_role_management_policy" "owners_policy" {
+  group_id = azuread_group.example.id
+  role_id = "owner"
+}
+```
+
+## Argument Reference
+
+* `group_id` - (Required) The ID of the Azure AD group for which the policy applies.
+* `role_id` - (Required) The type of assignment this policy coveres. Can be either `member` or `owner`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` (String) The ID of this policy.

--- a/docs/data-sources/group_role_management_policy.md
+++ b/docs/data-sources/group_role_management_policy.md
@@ -10,7 +10,7 @@ Use this data source to retrieve a role policy for an Azure AD group.
 
 The following API permissions are required in order to use this resource.
 
-When authenticated with a service principal, this resource requires the `RoleManagementPolicy.ReadWrite.AzureADGroup` Microsoft Graph API permissions.
+When authenticated with a service principal, this resource requires the `RoleManagementPolicy.Read.AzureADGroup` Microsoft Graph API permissions.
 
 When authenticated with a user principal, this resource requires `Global Administrator` directory role, or the `Privileged Role Administrator` role in Identity Governance.
 

--- a/docs/resources/group_role_management_policy.md
+++ b/docs/resources/group_role_management_policy.md
@@ -44,8 +44,8 @@ resource "azuread_group_role_management_policy" "example" {
   notification_rules {
     approver_notifications {
       eligible_assignments {
-        notification_level    = "Critical"
-        default_recipients    = false
+        notification_level = "Critical"
+        default_recipients = false
         additional_recipients = [
           "someone@example.com",
           "someone.else@example.com",

--- a/internal/services/identitygovernance/privileged_access_group_assignment_schedule_test.go
+++ b/internal/services/identitygovernance/privileged_access_group_assignment_schedule_test.go
@@ -131,11 +131,11 @@ resource "azuread_group" "pam" {
   mail_enabled     = false
   security_enabled = true
 
-	owners = [azuread_user.manual_owner.object_id]
+  owners = [azuread_user.manual_owner.object_id]
 
-	lifecycle {
-		ignore_changes = [owners]
-	}
+  lifecycle {
+    ignore_changes = [owners]
+  }
 }
 
 resource "azuread_user" "eligibile_owner" {

--- a/internal/services/identitygovernance/privileged_access_group_eligiblity_schedule_test.go
+++ b/internal/services/identitygovernance/privileged_access_group_eligiblity_schedule_test.go
@@ -130,11 +130,11 @@ resource "azuread_group" "pam" {
   mail_enabled     = false
   security_enabled = true
 
-	owners = [azuread_user.manual_owner.object_id]
+  owners = [azuread_user.manual_owner.object_id]
 
-	lifecycle {
-		ignore_changes = [owners]
-	}
+  lifecycle {
+    ignore_changes = [owners]
+  }
 }
 
 resource "azuread_user" "eligibile_owner" {

--- a/internal/services/policies/group_role_management_policy_data_source.go
+++ b/internal/services/policies/group_role_management_policy_data_source.go
@@ -70,7 +70,7 @@ func (r GroupRoleManagementPolicyDataSource) Read() sdk.ResourceFunc {
 
 			groupID := metadata.ResourceData.Get("group_id").(string)
 			roleID := metadata.ResourceData.Get("role_id").(string)
-			id, err := getPolicyId(ctx, sdk.ResourceMetaData{Client: metadata.Client}, groupID, roleID)
+			id, err := getPolicyId(ctx, metadata, groupID, roleID)
 			if err != nil {
 				return errors.New("Bad API response")
 			}

--- a/internal/services/policies/group_role_management_policy_data_source.go
+++ b/internal/services/policies/group_role_management_policy_data_source.go
@@ -6,6 +6,7 @@ package policies
 import (
 	"context"
 	"errors"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azuread/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azuread/internal/tf/pluginsdk"

--- a/internal/services/policies/group_role_management_policy_data_source.go
+++ b/internal/services/policies/group_role_management_policy_data_source.go
@@ -7,59 +7,79 @@ import (
 	"context"
 	"errors"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
 	"github.com/hashicorp/terraform-provider-azuread/internal/sdk"
-	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
-	"time"
-
 	"github.com/hashicorp/terraform-provider-azuread/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azuread/internal/tf/validation"
 	"github.com/manicminer/hamilton/msgraph"
 )
 
-func groupRoleManagementPolicyDataSource() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
-		ReadContext: groupRoleManagementPolicyDataSourceRead,
+var _ sdk.DataSource = GroupRoleManagementPolicyDataSource{}
 
-		Timeouts: &pluginsdk.ResourceTimeout{
-			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
+type GroupRoleManagementPolicyDataSource struct{}
+
+func (r GroupRoleManagementPolicyDataSource) Arguments() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"group_id": {
+			Description:      "ID of the group to which this policy is assigned",
+			Type:             pluginsdk.TypeString,
+			Required:         true,
+			ForceNew:         true,
+			ValidateDiagFunc: validation.ValidateDiag(validation.IsUUID),
 		},
 
-		Schema: map[string]*schema.Schema{
-			"group_id": {
-				Description:      "ID of the group to which this policy is assigned",
-				Type:             pluginsdk.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: validation.ValidateDiag(validation.IsUUID),
-			},
-
-			"role_id": {
-				Description: "The ID of the role of this policy to the group",
-				Type:        pluginsdk.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				ValidateDiagFunc: validation.ValidateDiag(validation.StringInSlice([]string{
-					msgraph.PrivilegedAccessGroupRelationshipMember,
-					msgraph.PrivilegedAccessGroupRelationshipOwner,
-					msgraph.PrivilegedAccessGroupRelationshipUnknown,
-				}, false)),
-			},
+		"role_id": {
+			Description: "The ID of the role of this policy to the group",
+			Type:        pluginsdk.TypeString,
+			Required:    true,
+			ForceNew:    true,
+			ValidateDiagFunc: validation.ValidateDiag(validation.StringInSlice([]string{
+				msgraph.PrivilegedAccessGroupRelationshipMember,
+				msgraph.PrivilegedAccessGroupRelationshipOwner,
+				msgraph.PrivilegedAccessGroupRelationshipUnknown,
+			}, false)),
 		},
 	}
 }
 
-func groupRoleManagementPolicyDataSourceRead(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) pluginsdk.Diagnostics {
-	client := meta.(*clients.Client).Groups.GroupsClient
-	client.BaseClient.DisableRetries = true
-	defer func() { client.BaseClient.DisableRetries = false }()
+func (r GroupRoleManagementPolicyDataSource) Attributes() map[string]*schema.Schema {
+	return map[string]*pluginsdk.Schema{
+		"display_name": {
+			Description: "The display name of the policy",
+			Type:        pluginsdk.TypeString,
+			Computed:    true,
+		},
 
-	groupID := d.Get("group_id").(string)
-	roleID := d.Get("role_id").(string)
-	id, err := getPolicyId(ctx, sdk.ResourceMetaData{Client: meta.(*clients.Client)}, groupID, roleID)
-	if err != nil {
-		return tf.ErrorDiagF(errors.New("Bad API response"), "ID is nil for returned Group Role Management Policy", "group_id", groupID, "role_id", roleID)
+		"description": {
+			Description: "Description of the policy",
+			Type:        pluginsdk.TypeString,
+			Computed:    true,
+		},
 	}
-	d.SetId(id.ID())
-	return nil
+}
+
+func (r GroupRoleManagementPolicyDataSource) ModelObject() interface{} {
+	return &GroupRoleManagementPolicyModel{}
+}
+
+func (r GroupRoleManagementPolicyDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Groups.GroupsClient
+			client.BaseClient.DisableRetries = true
+			defer func() { client.BaseClient.DisableRetries = false }()
+
+			groupID := metadata.ResourceData.Get("group_id").(string)
+			roleID := metadata.ResourceData.Get("role_id").(string)
+			id, err := getPolicyId(ctx, sdk.ResourceMetaData{Client: metadata.Client}, groupID, roleID)
+			if err != nil {
+				return errors.New("Bad API response")
+			}
+			metadata.ResourceData.SetId(id.ID())
+			return nil
+		},
+	}
+}
+
+func (r GroupRoleManagementPolicyDataSource) ResourceType() string {
+	return "azuread_group_role_management_policy"
 }

--- a/internal/services/policies/group_role_management_policy_data_source.go
+++ b/internal/services/policies/group_role_management_policy_data_source.go
@@ -1,0 +1,65 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package policies
+
+import (
+	"context"
+	"errors"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"time"
+
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf/validation"
+	"github.com/manicminer/hamilton/msgraph"
+)
+
+func groupRoleManagementPolicyDataSource() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		ReadContext: groupRoleManagementPolicyDataSourceRead,
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"group_id": {
+				Description:      "ID of the group to which this policy is assigned",
+				Type:             pluginsdk.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validation.ValidateDiag(validation.IsUUID),
+			},
+
+			"role_id": {
+				Description: "The ID of the role of this policy to the group",
+				Type:        pluginsdk.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				ValidateDiagFunc: validation.ValidateDiag(validation.StringInSlice([]string{
+					msgraph.PrivilegedAccessGroupRelationshipMember,
+					msgraph.PrivilegedAccessGroupRelationshipOwner,
+					msgraph.PrivilegedAccessGroupRelationshipUnknown,
+				}, false)),
+			},
+		},
+	}
+}
+
+func groupRoleManagementPolicyDataSourceRead(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) pluginsdk.Diagnostics {
+	client := meta.(*clients.Client).Groups.GroupsClient
+	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
+
+	groupID := d.Get("group_id").(string)
+	roleID := d.Get("role_id").(string)
+	id, err := getPolicyId(ctx, sdk.ResourceMetaData{Client: meta.(*clients.Client)}, groupID, roleID)
+	if err != nil {
+		return tf.ErrorDiagF(errors.New("Bad API response"), "ID is nil for returned Group Role Management Policy", "group_id", groupID, "role_id", roleID)
+	}
+	d.SetId(id.ID())
+	return nil
+}

--- a/internal/services/policies/group_role_management_policy_data_source_test.go
+++ b/internal/services/policies/group_role_management_policy_data_source_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package policies_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+)
+
+type GroupRoleManagementPolicyDataSource struct{}
+
+func TestGroupRoleManagementPolicyDataSource_member(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azuread_group_role_management_policy", "test")
+	r := GroupRoleManagementPolicyDataSource{}
+
+	// Ignore the dangling resource post-test as the policy remains while the group is in a pending deletion state
+	data.ResourceTestIgnoreDangling(t, r, []acceptance.TestStep{
+		{
+			Config: r.member(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (GroupRoleManagementPolicyDataSource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	client := clients.Policies.RoleManagementPolicyClient
+	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
+
+	_, status, err := client.Get(ctx, state.ID)
+	if err != nil {
+		if status == http.StatusNotFound {
+			return pointer.To(false), nil
+		}
+		return nil, fmt.Errorf("failed to retrieve role management policy with ID %q: %+v", state.ID, err)
+	}
+
+	return pointer.To(true), nil
+}
+
+func (GroupRoleManagementPolicyDataSource) member(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_group" "pam" {
+  display_name     = "PAM Member Test %[1]s"
+  mail_enabled     = false
+  security_enabled = true
+}
+
+data "azuread_group_role_management_policy" "test" {
+  group_id = azuread_group_role_management_policy.test.group_id
+  role_id  = "member"
+}
+`, data.RandomString)
+}

--- a/internal/services/policies/group_role_management_policy_resource_test.go
+++ b/internal/services/policies/group_role_management_policy_resource_test.go
@@ -93,22 +93,22 @@ resource "azuread_group_role_management_policy" "test" {
     expire_after = "P365D"
   }
 
-	notification_rules {
-		eligible_assignments {
-		  approver_notifications {
-				notification_level    = "Critical"
-				default_recipients    = false
-				additional_recipients = ["someone@example.com"]
-			}
-		}
-		eligible_activations {
-		  assignee_notifications {
-				notification_level    = "All"
-				default_recipients    = true
-				additional_recipients = ["someone@example.com"]
-			}
-		}
-	}
+  notification_rules {
+    eligible_assignments {
+      approver_notifications {
+        notification_level    = "Critical"
+        default_recipients    = false
+        additional_recipients = ["someone@example.com"]
+      }
+    }
+    eligible_activations {
+      assignee_notifications {
+        notification_level    = "All"
+        default_recipients    = true
+        additional_recipients = ["someone@example.com"]
+      }
+    }
+  }
 }
 `, data.RandomString)
 }
@@ -120,9 +120,9 @@ provider "azuread" {}
 data "azuread_domains" "test" {
   only_initial = true
 }
- 
+
 resource "azuread_user" "approver" {
-	user_principal_name = "pam-approver-%[1]s@${data.azuread_domains.test.domains.0.domain_name}"
+  user_principal_name = "pam-approver-%[1]s@${data.azuread_domains.test.domains.0.domain_name}"
   display_name        = "PAM Approver Test %[1]s"
   password            = "%[2]s"
 }
@@ -145,26 +145,26 @@ resource "azuread_group_role_management_policy" "test" {
     expire_after = "P90D"
   }
 
-	activation_rules {
-		maximum_duration = "PT1H"
-		require_approval = true
-		approval_stage {
-			primary_approver {
-				object_id = azuread_user.approver.object_id
-				type      = "singleUser" 
-			}
-		}
-	}
+  activation_rules {
+    maximum_duration = "PT1H"
+    require_approval = true
+    approval_stage {
+      primary_approver {
+        object_id = azuread_user.approver.object_id
+        type      = "singleUser"
+      }
+    }
+  }
 
-	notification_rules {
-		active_assignments {
-			admin_notifications {
-				notification_level    = "Critical"
-				default_recipients    = false
-				additional_recipients = ["someone@example.com"]
-			}
-		}
-	}
+  notification_rules {
+    active_assignments {
+      admin_notifications {
+        notification_level    = "Critical"
+        default_recipients    = false
+        additional_recipients = ["someone@example.com"]
+      }
+    }
+  }
 }
 `, data.RandomString, data.RandomPassword)
 }

--- a/internal/services/policies/registration.go
+++ b/internal/services/policies/registration.go
@@ -29,7 +29,9 @@ func (r Registration) WebsiteCategories() []string {
 
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
-	return map[string]*pluginsdk.Resource{}
+	return map[string]*pluginsdk.Resource{
+		"azuread_group_role_management_policy": groupRoleManagementPolicyDataSource(),
+	}
 }
 
 // SupportedResources returns the supported Resources supported by this Service

--- a/internal/services/policies/registration.go
+++ b/internal/services/policies/registration.go
@@ -29,9 +29,7 @@ func (r Registration) WebsiteCategories() []string {
 
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
-	return map[string]*pluginsdk.Resource{
-		"azuread_group_role_management_policy": groupRoleManagementPolicyDataSource(),
-	}
+	return map[string]*pluginsdk.Resource{}
 }
 
 // SupportedResources returns the supported Resources supported by this Service
@@ -44,7 +42,9 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 
 // DataSources returns the typed DataSources supported by this service
 func (r Registration) DataSources() []sdk.DataSource {
-	return []sdk.DataSource{}
+	return []sdk.DataSource{
+		GroupRoleManagementPolicyDataSource{},
+	}
 }
 
 // Resources returns the typed Resources supported by this service


### PR DESCRIPTION
Adds a data source to allow easy lookup for the policy id during import:

```hcl
resource "azuread_group_role_management_policy" "owners_policy" {
  group_id = azuread_group.test.id
  role_id  = "owner"

  eligible_assignment_rules {
    expiration_required = true
  }

  active_assignment_rules {
    expire_after = "P180D"
  }

  notification_rules {
    eligible_assignments {
      approver_notifications {
        notification_level = "All"
        default_recipients = true
      }
    }
  }
}

data "azuread_group_role_management_policy" "owners_policy" {
  group_id = azuread_group.test.id
  role_id  = "owner"
}

import {
  to = azuread_group_role_management_policy.owners_policy
  id = data.azuread_group_role_management_policy.owners_policy.id
}
```